### PR TITLE
.gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+objects/

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 objects/
+result/
 TG_3D

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 objects/
+TG_3D


### PR DESCRIPTION
Add `.gitignore` file for more pretty work with the repo. Now `git` doesn't track annoying `./objects/`, `./result/` and `./TG_3D` paths